### PR TITLE
Feature/ab#2235 change deployment to statefulset

### DIFF
--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -15,6 +15,10 @@ springdoc:
     csrf:
       enabled: 'true'
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
+      - org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration
   flyway:
     baseline-on-migrate: 'true'
     locations: classpath:db/migration

--- a/deployment/helm/urbalytix/templates/deployment.yaml
+++ b/deployment/helm/urbalytix/templates/deployment.yaml
@@ -51,9 +51,11 @@ spec:
               value: {{ .Values.database.username }}
             - name: SPRING_DATASOURCE_PASSWORD
               value: {{ .Values.database.password }}
+            - name: SPRING_DATA_VEHICLE-ROUTES_AGGREGATIONINTERVALMS
+              value: {{ .Values.app.spring_data.vehicle_routes.aggregationIntervalMs | quote }}
+            - name: SPRING_DATA_VEHICLE-ROUTES_SECTIONMAXGAPMS
+              value: {{ .Values.app.spring_data.vehicle_routes.sectionMaxGapMs | quote }}
             {{- if .Values.auth.enabled }}
-            - name: SPRING_DATA_DETECTION_SCALE
-              value: {{ .Values.app.spring_data.detection_scale | quote }}
             - name: SPRING_PROFILES_ACTIVE
               value: auth
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER-URI

--- a/deployment/helm/urbalytix/templates/deployment.yaml
+++ b/deployment/helm/urbalytix/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "urbalytix.selectorLabels" . | nindent 6 }}
@@ -86,9 +88,9 @@ spec:
             - name: INFRA_TRASH_SECRET
               value: {{ .Values.app.feature_collection.secret | quote}}
             {{- end }}
-            {{- if .Values.app.spring_data.redis_active }}
             - name: SPRING_DATA_REDIS_ACTIVE
-              value: "true"
+              value: {{ .Values.app.spring_data.redis_active | quote }}
+            {{- if .Values.app.spring_data.redis_active }}
             - name: SPRING_DATA_REDIS_HOST
               value: {{ .Values.app.spring_data.redis_host | quote}}
             - name: SPRING_DATA_REDIS_PORT

--- a/deployment/helm/urbalytix/templates/deployment.yaml
+++ b/deployment/helm/urbalytix/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
               value: {{ .Values.auth.clientSecret }}
             {{- else }}
             - name: SPRING_PROFILES_ACTIVE
-              value: default
+              value: dev
             {{- end }}
             {{- if .Values.app.feature_collection.enabled }}
             - name: INFRA_TRASH_ENDPOINT

--- a/deployment/helm/urbalytix/values.yaml
+++ b/deployment/helm/urbalytix/values.yaml
@@ -25,7 +25,9 @@ app:
     aggregator_stream_prefix: aggregator # if aggregation messages are published under a different name
     positionsource_stream_prefix: positionsource # if position messages are published under a different name
     detection_stream_prefix: objectdetector # if detection messages are published under a different name
-    detection_scale: 20 # scale factor of vehicle route density
+    vehicle_routes:
+      aggregationIntervalMs: 2000 # aggregate raw points into sub-sections by time interval
+      sectionMaxGapMs: 4000 # split route sections if data gap is larger than set value (by timestamp)
 
 service:
   port: 8081


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The title is misleading, as we have decided to keep the deployment resource but rather use the update strategy "recreate", which achieves roughly the same behavior in terms of pod update method. The old pod is stopped first then the new pod is started as opposed to starting the new pod in parallel and only shutting down the old one when the new one becomes ready.
Also, I've fixed two bugs with regard to app configuration and Helm chart:
- `SPRING_DATA_REDIS_ACTIVE` now behaves correctly (before redis components would still be initialized through autoconfiguration which influenced the readyness probe)
- `auth.enabled=false` (helm value) now behaves correctly (before it would activate the non existant default profile which lead to unconfigured but active authentication)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
