### PR TITLE
Feature/ab#2264 online indicator breaks

### DIFF
--- a/deployment/noauth-docker-compose.yml
+++ b/deployment/noauth-docker-compose.yml
@@ -30,6 +30,18 @@ services:
     ports:
       - "5050:80"
 
+  valkey:
+    image: valkey/valkey:9.0.3
+    command: ["valkey-server", "/usr/local/etc/valkey/valkey.conf"]
+    ports:
+      - 6379:6379
+    volumes:
+      - ./valkey/valkey.conf:/usr/local/etc/valkey/valkey.conf
+    healthcheck:
+      test: "[ \"$(valkey-cli ping)\" = \"PONG\" ] && exit 0 || exit 1"
+      interval: 1s
+      start_period: 5s
+
 volumes:
   pgadmin:
   db-urbalytix:

--- a/deployment/valkey/valkey.conf
+++ b/deployment/valkey/valkey.conf
@@ -1,0 +1,2 @@
+save ""
+appendonly no

--- a/docs/Readme-dev.md
+++ b/docs/Readme-dev.md
@@ -50,6 +50,16 @@ Once all steps ran successfully application will be reachable with the following
   * default user/password is admin/admin
   * keycloak can be reached under <http://localost:8081/auth>
 
+### Mock authentication
+When developing the frontend with the Vite dev server you usually don't want to run a full Keycloak instance. The dev server can mock the authentication endpoint instead, so the application treats you as a logged-in user.
+
+This is controlled via environment variables in `webclient/app/.env`:
+
+* `MOCK_AUTH=true` enables the mock. The Vite dev server intercepts `GET /urbalytix/api/user/current` and returns an authenticated user. Set it to anything else (or remove it) to disable the mock and use the real backend/Keycloak.
+* `MOCK_AUTH_ROLES` is a comma-separated list of roles assigned to the mocked user (e.g. `MOCK_AUTH_ROLES=admin,user`). If omitted, the user defaults to `admin`.
+
+The mock only applies to the Vite dev server (`npm run dev`); it has no effect on the packaged application.
+
 ### Run necessary infra
 Application needs various infrastructure to run e.g. PostgreSQL database. Folder [deployment](../deployment/) contains a number of Docker Compose scripts to run these. 
 

--- a/persistence/src/main/resources/db/migration/relational/V3_6__add_vehicle_online_threshold.sql
+++ b/persistence/src/main/resources/db/migration/relational/V3_6__add_vehicle_online_threshold.sql
@@ -1,0 +1,3 @@
+INSERT INTO "configuration" ("keyname", "valuefield", "category", "datatype")
+VALUES
+    ('vehicledata.onlineThresholdSec', '30', 'vehicle', 'INTEGER');

--- a/rest/src/main/java/de/starwit/rest/controller/VehicleDataController.java
+++ b/rest/src/main/java/de/starwit/rest/controller/VehicleDataController.java
@@ -38,9 +38,8 @@ public class VehicleDataController {
 
     @Operation(summary = "Get all vehicles")
     @GetMapping
-    public List<VehicleDataEntity> findAll() {
-        List<VehicleDataEntity> list = this.vehicleDataService.findAll();
-        return list;
+    public List<VehicleStatisticsDto> findAll() {
+        return this.vehicleDataService.findAllWithStatus();
     }
 
     @Operation(summary = "Get all vehicles with statistics")

--- a/service/src/main/java/de/starwit/service/dto/VehicleStatisticsDto.java
+++ b/service/src/main/java/de/starwit/service/dto/VehicleStatisticsDto.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import org.locationtech.jts.geom.Point;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import de.starwit.persistence.entity.VehicleDataEntity;
 
 public class VehicleStatisticsDto {
@@ -20,6 +22,9 @@ public class VehicleStatisticsDto {
     private Point location;
 
     private ZonedDateTime lastUpdate;
+
+    @JsonProperty("isOnline")
+    private boolean isOnline;
 
     Map<ZonedDateTime, Double> distances = new java.util.HashMap<>();
 
@@ -83,6 +88,14 @@ public class VehicleStatisticsDto {
 
     public void setLastUpdate(ZonedDateTime lastUpdate) {
         this.lastUpdate = lastUpdate;
+    }
+
+    public boolean isOnline() {
+        return isOnline;
+    }
+
+    public void setOnline(boolean isOnline) {
+        this.isOnline = isOnline;
     }
 
     public Map<ZonedDateTime, Double> getDistances() {

--- a/service/src/main/java/de/starwit/service/impl/VehicleDataService.java
+++ b/service/src/main/java/de/starwit/service/impl/VehicleDataService.java
@@ -1,6 +1,7 @@
 package de.starwit.service.impl;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -15,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import de.starwit.persistence.entity.ConfigurationEntity;
 import de.starwit.persistence.entity.VehicleDataEntity;
 import de.starwit.persistence.entity.VehicleRouteEntity;
 import de.starwit.persistence.repository.VehicleDataRepository;
@@ -27,6 +29,9 @@ public class VehicleDataService implements ServiceInterface<VehicleDataEntity, V
 
     private Logger log = LoggerFactory.getLogger(this.getClass());
 
+    private static final String ONLINE_THRESHOLD_KEY = "vehicledata.onlineThresholdSec";
+    private static final long DEFAULT_ONLINE_THRESHOLD_SEC = 30;
+
     // TODO get from configuration
     ZoneId timeZone = ZoneId.of("Europe/Berlin");
 
@@ -37,6 +42,9 @@ public class VehicleDataService implements ServiceInterface<VehicleDataEntity, V
     private VehicleRoutesRepository routesRepository;
 
     @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
     private GeometryFactory geometryFactory;
 
     @Override
@@ -44,12 +52,30 @@ public class VehicleDataService implements ServiceInterface<VehicleDataEntity, V
         return repository;
     }
 
+    /**
+     * Returns all vehicles as DTOs including their current online/offline status,
+     * without the (expensive) per-timeframe distance aggregation. Used by the map
+     * view, which polls this frequently.
+     */
+    public List<VehicleStatisticsDto> findAllWithStatus() {
+        long thresholdSec = getOnlineThresholdSec();
+        List<VehicleStatisticsDto> result = new ArrayList<>();
+        for (VehicleDataEntity vehicle : repository.findAll()) {
+            VehicleStatisticsDto dto = new VehicleStatisticsDto(vehicle);
+            dto.setOnline(isOnline(vehicle.getLastUpdate(), thresholdSec));
+            result.add(dto);
+        }
+        return result;
+    }
+
     public List<VehicleStatisticsDto> findAllWithDistances(ZonedDateTime startTime, ZonedDateTime endTime) {
+        long thresholdSec = getOnlineThresholdSec();
         List<VehicleStatisticsDto> result = new ArrayList<>();
         List<VehicleDataEntity> vehicles = repository.findAll();
         log.debug("Calculating distances for " + vehicles.size() + " vehicles");
         for (VehicleDataEntity vehicle : vehicles) {
             VehicleStatisticsDto dto = new VehicleStatisticsDto(vehicle);
+            dto.setOnline(isOnline(vehicle.getLastUpdate(), thresholdSec));
             result.add(dto);
         }
 
@@ -71,6 +97,33 @@ public class VehicleDataService implements ServiceInterface<VehicleDataEntity, V
 
         return result;
 
+    }
+
+    /**
+     * Reads the configured online threshold (in seconds), falling back to
+     * {@value #DEFAULT_ONLINE_THRESHOLD_SEC} when the config entry is missing or
+     * not a valid number.
+     */
+    private long getOnlineThresholdSec() {
+        ConfigurationEntity config = configurationService.findByKey(ONLINE_THRESHOLD_KEY);
+        if (config == null) {
+            return DEFAULT_ONLINE_THRESHOLD_SEC;
+        }
+        try {
+            return Long.parseLong(config.getValuefield());
+        } catch (NumberFormatException e) {
+            log.warn("Invalid value '{}' for config key {}, falling back to default {}s",
+                    config.getValuefield(), ONLINE_THRESHOLD_KEY, DEFAULT_ONLINE_THRESHOLD_SEC);
+            return DEFAULT_ONLINE_THRESHOLD_SEC;
+        }
+    }
+
+    private boolean isOnline(ZonedDateTime lastUpdate, long thresholdSec) {
+        if (lastUpdate == null) {
+            return false;
+        }
+        long secondsSinceUpdate = Duration.between(lastUpdate, ZonedDateTime.now(timeZone)).getSeconds();
+        return secondsSinceUpdate <= thresholdSec;
     }
 
     public void insertOrUpdatePosition(String streamKey, PositionMessage positionMessage) {

--- a/service/src/test/java/de/starwit/service/VehicleDataServiceTest.java
+++ b/service/src/test/java/de/starwit/service/VehicleDataServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import de.starwit.persistence.entity.VehicleRouteEntity;
 import de.starwit.persistence.repository.VehicleDataRepository;
 import de.starwit.persistence.repository.VehicleRoutesRepository;
+import de.starwit.service.impl.ConfigurationService;
 import de.starwit.service.impl.VehicleDataService;
 import de.starwit.visionapi.Common.GeoCoordinate;
 import de.starwit.visionapi.Common.MovementVector;
@@ -20,6 +21,9 @@ import de.starwit.visionapi.Sae.PositionMessage;
 
 @SpringBootTest(classes = { VehicleDataService.class, GeometryFactory.class })
 public class VehicleDataServiceTest {
+
+    @MockitoBean
+    private ConfigurationService configurationService;
 
     @MockitoBean
     private VehicleDataRepository dataRepository;

--- a/webclient/app/src/app/commons/geographicalMaps/MapLayerFactory.js
+++ b/webclient/app/src/app/commons/geographicalMaps/MapLayerFactory.js
@@ -157,7 +157,7 @@ export class MapLayerFactory {
         return new IconLayer({
             id: `IconLayer-vehicle-positions`,
             data: positionData,
-            getColor: d => d.status === 'online' ? [100, 155, 100] : [155, 50, 50],
+            getColor: d => d.isOnline ? [100, 155, 100] : [155, 50, 50],
             getIcon: d => 'marker',
             getPosition: d => d.location ? d.location : [d.longitude, d.latitude],
             sizeUnits: "meters",

--- a/webclient/app/src/app/features/adminarea/vehicle/VehicleRouteMap.jsx
+++ b/webclient/app/src/app/features/adminarea/vehicle/VehicleRouteMap.jsx
@@ -1,4 +1,5 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
+import {useTranslation} from "react-i18next";
 import positionImage from "../../../assets/icons/vehicle.png";
 import BaseMap from '../../../commons/geographicalMaps/BaseMap';
 import {MapLayerFactory} from '../../../commons/geographicalMaps/MapLayerFactory';
@@ -13,22 +14,8 @@ const ICON_MAPPING = {
     },
 }
 
-function renderTooltip({layer, object}) {
-    if (!object || !layer) {
-        return;
-    }
-
-    if (layer.id.startsWith("LineLayer-route-points")) {
-        return `${object.timestamp}\n${object.speedKmhAvg.toFixed(2)}km/h`;
-    }
-
-    if (layer.id.startsWith("IconLayer-vehicle-positions")) {
-        return `${object.name}\n${object.lastUpdate}\n${object.isOnline ? "online" : "offline"}`;
-    }
-
-}
-
 function VehicleRouteMap(props) {
+    const {t} = useTranslation();
     const {
         viewState,
         onViewStateChange,
@@ -38,6 +25,21 @@ function VehicleRouteMap(props) {
         positionIcon = positionImage,
         positionData = [],
     } = props;
+
+    function renderTooltip({layer, object}) {
+        if (!object || !layer) {
+            return;
+        }
+
+        if (layer.id.startsWith("LineLayer-route-points")) {
+            return `${object.timestamp}\n${object.speedKmhAvg.toFixed(2)}km/h`;
+        }
+
+        if (layer.id.startsWith("IconLayer-vehicle-positions")) {
+            const status = t(`vehicle.status.${object.isOnline ? "online" : "offline"}`);
+            return `${object.name}\n${object.lastUpdate}\n${status}`;
+        }
+    }
 
     let layers = [
         MapLayerFactory.createDistrictLayer(districts, showDistricts, false, () => { }),

--- a/webclient/app/src/app/features/adminarea/vehicle/VehicleRouteMap.jsx
+++ b/webclient/app/src/app/features/adminarea/vehicle/VehicleRouteMap.jsx
@@ -23,7 +23,7 @@ function renderTooltip({layer, object}) {
     }
 
     if (layer.id.startsWith("IconLayer-vehicle-positions")) {
-        return `${object.name}\n${object.lastUpdate}\n${object.status}`;
+        return `${object.name}\n${object.lastUpdate}\n${object.isOnline ? "online" : "offline"}`;
     }
 
 }

--- a/webclient/app/src/app/features/adminarea/vehicle/VehicleTable.jsx
+++ b/webclient/app/src/app/features/adminarea/vehicle/VehicleTable.jsx
@@ -60,14 +60,14 @@ function VehicleTable(props) {
             flex: 0.2
         },
         {
-            field: "status",
+            field: "isOnline",
             headerName: t("vehicledata.status"),
             flex: 0.08,
             editable: false,
             renderCell: vehicle => {
                 return (
-                    <Tooltip title={t(`vehicle.status.${vehicle.row.status}`)}>
-                        <VehicleIcon color={vehicle.row.status == "online" ? "success" : "error"} />
+                    <Tooltip title={t(`vehicle.status.${vehicle.row.isOnline ? "online" : "offline"}`)}>
+                        <VehicleIcon color={vehicle.row.isOnline ? "success" : "error"} />
                     </Tooltip >
                 );
             }

--- a/webclient/app/src/app/services/VehicleDataRest.js
+++ b/webclient/app/src/app/services/VehicleDataRest.js
@@ -12,10 +12,7 @@ class VehicleDataRest extends CrudRest {
             return response;
         }
         for (const vehicle of response.data) {
-            const lastUpdate = new Date(vehicle.lastUpdate);
-            const diffInSeconds = ((new Date() - lastUpdate) / 1000);
-            vehicle.status = diffInSeconds <= 30 ? "online" : "offline";
-            vehicle.lastUpdate = lastUpdate.toLocaleString();
+            vehicle.lastUpdate = new Date(vehicle.lastUpdate).toLocaleString();
         }
         return response;
     }
@@ -26,10 +23,7 @@ class VehicleDataRest extends CrudRest {
             return [];
         }
         for (const vehicle of response.data) {
-            const lastUpdate = new Date(vehicle.lastUpdate);
-            const diffInSeconds = ((new Date() - lastUpdate) / 1000);
-            vehicle.status = diffInSeconds <= 30 ? "online" : "offline";
-            vehicle.lastUpdate = lastUpdate.toLocaleString();
+            vehicle.lastUpdate = new Date(vehicle.lastUpdate).toLocaleString();
         }
 
         return response;

--- a/webclient/app/src/app/services/VehicleDataRest.js
+++ b/webclient/app/src/app/services/VehicleDataRest.js
@@ -12,10 +12,10 @@ class VehicleDataRest extends CrudRest {
             return response;
         }
         for (const vehicle of response.data) {
-            vehicle.lastUpdate = new Date(vehicle.lastUpdate).toLocaleString();
-            const now = new Date();
-            const diffInSeconds = ((now - new Date(vehicle.lastUpdate)) / 1000);
+            const lastUpdate = new Date(vehicle.lastUpdate);
+            const diffInSeconds = ((new Date() - lastUpdate) / 1000);
             vehicle.status = diffInSeconds <= 30 ? "online" : "offline";
+            vehicle.lastUpdate = lastUpdate.toLocaleString();
         }
         return response;
     }
@@ -26,10 +26,10 @@ class VehicleDataRest extends CrudRest {
             return [];
         }
         for (const vehicle of response.data) {
-            vehicle.lastUpdate = new Date(vehicle.lastUpdate).toLocaleString();
-            const now = new Date();
-            const diffInSeconds = ((now - new Date(vehicle.lastUpdate)) / 1000);
+            const lastUpdate = new Date(vehicle.lastUpdate);
+            const diffInSeconds = ((new Date() - lastUpdate) / 1000);
             vehicle.status = diffInSeconds <= 30 ? "online" : "offline";
+            vehicle.lastUpdate = lastUpdate.toLocaleString();
         }
 
         return response;

--- a/webclient/app/src/localization/translation-de-DE.js
+++ b/webclient/app/src/localization/translation-de-DE.js
@@ -136,6 +136,8 @@ const translationDeDE = {
     "config.category.general": "Allgemein",
     "config.category.map": "Karte",
     "config.category.datasources": "Datenquellen",
+    "config.category.vehicle": "Fahrzeuge",
+    "config.item.vehicledata.onlineThresholdSec": "Fahrzeug Online-Schwelle (Sekunden)",
     "config.item.location_lon": "Längengrad Kartenansicht",
     "config.item.location_lat": "Breitengrad Kartenansicht",
     "config.item.city": "Stadtname",

--- a/webclient/app/src/localization/translation-en-EN.js
+++ b/webclient/app/src/localization/translation-en-EN.js
@@ -136,6 +136,8 @@ const translationEnEN = {
     "config.category.general": "General",
     "config.category.map": "Map",
     "config.category.datasources": "Data Sources",
+    "config.category.vehicle": "Vehicles",
+    "config.item.vehicledata.onlineThresholdSec": "Vehicle online threshold (seconds)",
     "config.item.location_lon": "Map default longitude",
     "config.item.location_lat": "Map default latitude",
     "config.item.city": "City name",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Move isOnline calculation for vehicles to backend (thereby fix the bug that depended on browser settings) and refactor slightly
   - Reuse `VehicleStatisticsDto`
   - Add config option for online/offline threshold (default 30s)
- Add Valkey to compose for easier testing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.